### PR TITLE
otterdog: set new default branch for manifest repo

### DIFF
--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -20,6 +20,7 @@ orgs.newOrg('eclipse-oniro4openharmony') {
     orgs.newRepo('manifest') {
       allow_auto_merge: true,
       allow_update_branch: false,
+      default_branch: "OpenHarmony-3.2-Release",
       delete_branch_on_merge: true,
       web_commit_signoff_required: true,
     },


### PR DESCRIPTION
The main branch does not exist in the original repo we mirror from (and thus creates problems when running git push --mirror).

In addition, our changes will be targeted into the OpenHarmony-3.2-Release branch, which means we should show it as default to make is easier to discover for contributors.