### PR TITLE
Update default branch for manifest repo

### DIFF
--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -36,7 +36,7 @@ orgs.newOrg('eclipse-oniro4openharmony') {
     orgs.newRepo('manifest') {
       allow_auto_merge: true,
       allow_update_branch: false,
-      default_branch: "OpenHarmony-3.2-Release",
+      default_branch: "OpenHarmony-4.0-Release",
     },
     orgs.newRepo('oniro-ide') {
       allow_rebase_merge: false,


### PR DESCRIPTION
We switched to the 4.0 release. Make it the default branch.