### PR TITLE
otterdog: create two new repos for third_party add-on's

### DIFF
--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -35,6 +35,16 @@ orgs.newOrg('eclipse-oniro4openharmony') {
       allow_update_branch: false,
       default_branch: "OpenHarmony-4.0-Release",
     },
+    orgs.newRepo('third_party_kanto') {
+      allow_auto_merge: true,
+      allow_update_branch: false,
+      allow_squash_merge: false,
+    },
+    orgs.newRepo('third_party_mosquitto') {
+      allow_auto_merge: true,
+      allow_update_branch: false,
+      allow_squash_merge: false,
+    },
     orgs.newRepo('oniro-ide') {
       allow_rebase_merge: false,
       allow_update_branch: false,


### PR DESCRIPTION
For the ongoing Kanto add-on work we need two new repositories to hold the code.