### PR TITLE
Switch default branch of third_party_mosquitto repo to oniro branch

### DIFF
--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -44,6 +44,7 @@ orgs.newOrg('eclipse-oniro4openharmony') {
       allow_auto_merge: true,
       allow_update_branch: false,
       allow_squash_merge: false,
+      default_branch: "oniro",
     },
     orgs.newRepo('oniro-ide') {
       allow_rebase_merge: false,


### PR DESCRIPTION
We use this branch for integration work. Separated from upstream work. Making it default in our fork.