### PR TITLE
otterdog: create two new repositories for F-OH

### DIFF
--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -68,5 +68,21 @@ orgs.newOrg('eclipse-oniro4openharmony') {
       description: "Fork of Eclipse Mosquitto for Oniro integration",
       homepage: "",
     },
+    orgs.newRepo('f-oh') {
+      allow_auto_merge: true,
+      allow_squash_merge: false,
+      allow_update_branch: false,
+      default_branch: "oniro",
+      description: "Fork of F-OH application store for Oniro",
+      homepage: "",
+    },
+    orgs.newRepo('f-oh-data') {
+      allow_auto_merge: true,
+      allow_squash_merge: false,
+      allow_update_branch: false,
+      default_branch: "oniro",
+      description: "Fork of F-OH backend for Oniro",
+      homepage: "",
+    },
   ],
 }


### PR DESCRIPTION
Oniro will work on f-oh as a example of an open source application store for Oniro.