### PR TITLE
otterdog: enable force push to remove repo README init commit

### DIFF
--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -71,7 +71,7 @@ orgs.newOrg('eclipse-oniro4openharmony') {
     orgs.newRepo('f-oh') {
       allow_auto_merge: true,
       allow_squash_merge: false,
-      allow_update_branch: false,
+      allow_update_branch: true,
       default_branch: "oniro",
       description: "Fork of F-OH application store for Oniro",
       homepage: "",
@@ -79,7 +79,7 @@ orgs.newOrg('eclipse-oniro4openharmony') {
     orgs.newRepo('f-oh-data') {
       allow_auto_merge: true,
       allow_squash_merge: false,
-      allow_update_branch: false,
+      allow_update_branch: true,
       default_branch: "oniro",
       description: "Fork of F-OH backend for Oniro",
       homepage: "",


### PR DESCRIPTION
This init repo commit does conflict with project history. Allow force push to remove it and switch back afterwards.