### PR TITLE
otterdog: add repo for appOniroNews 

### DIFF
--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -163,6 +163,7 @@ orgs.newOrg('oniro.oniro4openharmony', 'eclipse-oniro4openharmony') {
       default_branch: "main",
       description: "Oniro development planning",
       homepage: "",
+      has_discussions: true,
     },
     orgs.newRepo('device_board_oniro') {
       allow_auto_merge: true,

--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -24,7 +24,7 @@ orgs.newOrg('oniro.oniro4openharmony', 'eclipse-oniro4openharmony') {
       allow_squash_merge: false,
       allow_update_branch: false,
       description: "Oniro Documentation",
-      gh_pages_build_type: "legacy",
+      gh_pages_build_type: "workflow",
       gh_pages_source_branch: "main",
       gh_pages_source_path: "/",
       homepage: "https://docs.oniroproject.org/",

--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -353,5 +353,13 @@ orgs.newOrg('oniro.oniro4openharmony', 'eclipse-oniro4openharmony') {
       description: "A tool for building Oniro/OpenHarmony applications",
       homepage: "",
     },
+    orgs.newRepo('app-OniroNews') {
+      allow_auto_merge: true,
+      allow_squash_merge: false,
+      allow_update_branch: false,
+      default_branch: "main",
+      description: "Oniro News - a personalized news app",
+      homepage: "",
+    },
   ],
 }


### PR DESCRIPTION
- otterdog: add repo for appOniroNews 

Options changed to reflect live changes 
- otterdog/eclipse-oniro4openharmony.github.io: set gh_pages_build_type to workflow
- otterdog/oniro-planning: enable discussions