### PR TITLE
otterdog: configure docs repo with new github pages settings

### DIFF
--- a/otterdog/eclipse-oniro4openharmony.jsonnet
+++ b/otterdog/eclipse-oniro4openharmony.jsonnet
@@ -24,7 +24,8 @@ orgs.newOrg('oniro.oniro4openharmony', 'eclipse-oniro4openharmony') {
       allow_squash_merge: false,
       allow_update_branch: false,
       description: "Oniro Documentation",
-      gh_pages_build_type: "workflow",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
       homepage: "https://docs.oniroproject.org/",
       environments: [
         orgs.newEnvironment('github-pages') {


### PR DESCRIPTION
configure eclipse-oniro4openharmony.github.io repo github pages settings. Update gh_pages_build_type to legacy and set source branch to gh-pages for oniro documentation. This update properly configures the repository for the use of mkdocs